### PR TITLE
OPS-473 Add guzzlehttp/guzzle version ~7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.6.0",
-		"guzzlehttp/guzzle": "~6.0"
+		"guzzlehttp/guzzle": "~6.0|~7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
**Ticket**: https://nbox-341.atlassian.net/browse/OPS-473

This is needed for the Laravel 8 upgrade.